### PR TITLE
gpio_viewer.h Spelling error

### DIFF
--- a/src/gpio_viewer.h
+++ b/src/gpio_viewer.h
@@ -146,7 +146,7 @@ private:
 
     void printPWNTraps()
     {
-        Serial.printf("%d pins are PWM\n", ledcChannelPinCount);
+        Serial.printf("%d pins are PWN\n", ledcChannelPinCount);
         for (int i = 0; i < ledcChannelPinCount; i++)
         {
             Serial.printf("Pin %d is using channel %d\n", ledcChannelPin[i][0], ledcChannelPin[i][1]);


### PR DESCRIPTION
Spelling error in method printPWNTraps() line 1.
Changes 
Serial.printf("%d pins are PWM\n", ledcChannelPinCount); to Serial.printf("%d pins are PWN\n", ledcChannelPinCount);