### PR TITLE
Fix link in dependency list to point to the project's repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ platform = espressif32
 framework = arduino
 lib_deps =
     https://github.com/mathieucarbou/AsyncTCP.git
-    https://github.com/mathieucarbou/AsyncTCP.git
+    https://github.com/thelastoutpostworkshop/gpio_viewer.git
 ```
 
 ## Usage


### PR DESCRIPTION
Simple fix to the `README.md` file to fix the dependency list.